### PR TITLE
fix(users): grant first user admin

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -119,6 +119,17 @@ func (s *Server) ResolveOrCreateUser(ctx context.Context, req *usersv1.ResolveOr
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if created {
+		count, err := s.store.CountUsers(ctx)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "count users: %v", err)
+		}
+		if count == 1 {
+			if err := s.syncClusterRole(ctx, user.Meta.ID, usersv1.ClusterRole_CLUSTER_ROLE_ADMIN); err != nil {
+				return nil, status.Errorf(codes.Internal, "grant first user admin: %v", err)
+			}
+		}
+	}
 	return &usersv1.ResolveOrCreateUserResponse{User: toProtoUser(user), Created: created}, nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -110,7 +110,7 @@ func (s *Server) ResolveOrCreateUser(ctx context.Context, req *usersv1.ResolveOr
 	if oidcSubject == "" {
 		return nil, status.Error(codes.InvalidArgument, "oidc_subject must be provided")
 	}
-	user, created, err := s.store.ResolveOrCreateUser(ctx, store.UserInput{
+	user, created, count, err := s.store.ResolveOrCreateUser(ctx, store.UserInput{
 		OIDCSubject: oidcSubject,
 		Name:        req.GetName(),
 		Email:       req.GetEmail(),
@@ -119,15 +119,9 @@ func (s *Server) ResolveOrCreateUser(ctx context.Context, req *usersv1.ResolveOr
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	if created {
-		count, err := s.store.CountUsers(ctx)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "count users: %v", err)
-		}
-		if count == 1 {
-			if err := s.syncClusterRole(ctx, user.Meta.ID, usersv1.ClusterRole_CLUSTER_ROLE_ADMIN); err != nil {
-				return nil, status.Errorf(codes.Internal, "grant first user admin: %v", err)
-			}
+	if created && count == 1 {
+		if err := s.syncClusterRole(ctx, user.Meta.ID, usersv1.ClusterRole_CLUSTER_ROLE_ADMIN); err != nil {
+			return nil, status.Errorf(codes.Internal, "grant first user admin: %v", err)
 		}
 	}
 	return &usersv1.ResolveOrCreateUserResponse{User: toProtoUser(user), Created: created}, nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -80,6 +80,10 @@ func New(pool *pgxpool.Pool) *Store {
 	return &Store{pool: pool}
 }
 
+type rowQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
 func scanUser(row pgx.Row) (User, error) {
 	var user User
 	if err := row.Scan(
@@ -124,21 +128,46 @@ func scanAPIToken(row pgx.Row) (APIToken, error) {
 	return token, nil
 }
 
-func (s *Store) ResolveOrCreateUser(ctx context.Context, input UserInput) (User, bool, error) {
-	row := s.pool.QueryRow(ctx,
+func countUsers(ctx context.Context, querier rowQuerier) (int64, error) {
+	var count int64
+	err := querier.QueryRow(ctx, "SELECT count(*) FROM users").Scan(&count)
+	return count, err
+}
+
+func (s *Store) ResolveOrCreateUser(ctx context.Context, input UserInput) (User, bool, int64, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return User{}, false, 0, err
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if _, err := tx.Exec(ctx, "LOCK TABLE users IN SHARE ROW EXCLUSIVE MODE"); err != nil {
+		return User{}, false, 0, err
+	}
+
+	row := tx.QueryRow(ctx,
 		fmt.Sprintf(`SELECT %s FROM users WHERE oidc_subject = $1`, userColumns),
 		input.OIDCSubject,
 	)
 	user, err := scanUser(row)
 	if err == nil {
-		return user, false, nil
+		count, err := countUsers(ctx, tx)
+		if err != nil {
+			return User{}, false, 0, err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return User{}, false, 0, err
+		}
+		return user, false, count, nil
 	}
 	if !errors.Is(err, pgx.ErrNoRows) {
-		return User{}, false, err
+		return User{}, false, 0, err
 	}
 
 	identityID := uuid.New()
-	row = s.pool.QueryRow(ctx,
+	row = tx.QueryRow(ctx,
 		fmt.Sprintf(`INSERT INTO users (identity_id, oidc_subject, name, email, nickname, photo_url)
         VALUES ($1, $2, $3, $4, $5, $6)
         RETURNING %s`, userColumns),
@@ -153,31 +182,40 @@ func (s *Store) ResolveOrCreateUser(ctx context.Context, input UserInput) (User,
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			row = s.pool.QueryRow(ctx,
+			row = tx.QueryRow(ctx,
 				fmt.Sprintf(`SELECT %s FROM users WHERE oidc_subject = $1`, userColumns),
 				input.OIDCSubject,
 			)
 			user, err = scanUser(row)
 			if err != nil {
 				if errors.Is(err, pgx.ErrNoRows) {
-					return User{}, false, NotFound("user")
+					return User{}, false, 0, NotFound("user")
 				}
-				return User{}, false, err
+				return User{}, false, 0, err
 			}
-			return user, false, nil
+			count, err := countUsers(ctx, tx)
+			if err != nil {
+				return User{}, false, 0, err
+			}
+			if err := tx.Commit(ctx); err != nil {
+				return User{}, false, 0, err
+			}
+			return user, false, count, nil
 		}
-		return User{}, false, err
+		return User{}, false, 0, err
 	}
 
 	// TODO: Call Identity.RegisterIdentity(identityID, "user") here.
 
-	return user, true, nil
-}
+	count, err := countUsers(ctx, tx)
+	if err != nil {
+		return User{}, false, 0, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return User{}, false, 0, err
+	}
 
-func (s *Store) CountUsers(ctx context.Context) (int64, error) {
-	var count int64
-	err := s.pool.QueryRow(ctx, "SELECT count(*) FROM users").Scan(&count)
-	return count, err
+	return user, true, count, nil
 }
 
 func (s *Store) CreateUser(ctx context.Context, input UserInput) (User, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -135,6 +135,18 @@ func countUsers(ctx context.Context, querier rowQuerier) (int64, error) {
 }
 
 func (s *Store) ResolveOrCreateUser(ctx context.Context, input UserInput) (User, bool, int64, error) {
+	row := s.pool.QueryRow(ctx,
+		fmt.Sprintf(`SELECT %s FROM users WHERE oidc_subject = $1`, userColumns),
+		input.OIDCSubject,
+	)
+	user, err := scanUser(row)
+	if err == nil {
+		return user, false, 0, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return User{}, false, 0, err
+	}
+
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return User{}, false, 0, err
@@ -147,20 +159,16 @@ func (s *Store) ResolveOrCreateUser(ctx context.Context, input UserInput) (User,
 		return User{}, false, 0, err
 	}
 
-	row := tx.QueryRow(ctx,
+	row = tx.QueryRow(ctx,
 		fmt.Sprintf(`SELECT %s FROM users WHERE oidc_subject = $1`, userColumns),
 		input.OIDCSubject,
 	)
-	user, err := scanUser(row)
+	user, err = scanUser(row)
 	if err == nil {
-		count, err := countUsers(ctx, tx)
-		if err != nil {
-			return User{}, false, 0, err
-		}
 		if err := tx.Commit(ctx); err != nil {
 			return User{}, false, 0, err
 		}
-		return user, false, count, nil
+		return user, false, 0, nil
 	}
 	if !errors.Is(err, pgx.ErrNoRows) {
 		return User{}, false, 0, err
@@ -193,14 +201,10 @@ func (s *Store) ResolveOrCreateUser(ctx context.Context, input UserInput) (User,
 				}
 				return User{}, false, 0, err
 			}
-			count, err := countUsers(ctx, tx)
-			if err != nil {
-				return User{}, false, 0, err
-			}
 			if err := tx.Commit(ctx); err != nil {
 				return User{}, false, 0, err
 			}
-			return user, false, count, nil
+			return user, false, 0, nil
 		}
 		return User{}, false, 0, err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -174,6 +174,12 @@ func (s *Store) ResolveOrCreateUser(ctx context.Context, input UserInput) (User,
 	return user, true, nil
 }
 
+func (s *Store) CountUsers(ctx context.Context) (int64, error) {
+	var count int64
+	err := s.pool.QueryRow(ctx, "SELECT count(*) FROM users").Scan(&count)
+	return count, err
+}
+
 func (s *Store) CreateUser(ctx context.Context, input UserInput) (User, error) {
 	identityID := uuid.New()
 	row := s.pool.QueryRow(ctx,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
@@ -41,6 +42,12 @@ func TestUsersServiceE2E(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, createResp.Created)
 		require.Equal(t, subject, createResp.User.OidcSubject)
+
+		authedCtx := metadata.AppendToOutgoingContext(ctx, "x-identity-id", createResp.User.Meta.Id)
+		meResp, err := client.GetMe(authedCtx, &usersv1.GetMeRequest{})
+		require.NoError(t, err)
+		require.Equal(t, createResp.User.Meta.Id, meResp.User.Meta.Id)
+		require.Equal(t, usersv1.ClusterRole_CLUSTER_ROLE_ADMIN, meResp.ClusterRole)
 
 		resolveResp, err := client.ResolveOrCreateUser(ctx, &usersv1.ResolveOrCreateUserRequest{
 			OidcSubject: subject,


### PR DESCRIPTION
## Summary
- serialize ResolveOrCreateUser insert + count in a transaction to avoid first-user race
- return user count from the store to drive first-admin grants
- extend e2e coverage to assert the first user gets admin role

## Testing
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go build ./...