### PR TITLE
fix(server): register identity on resolve

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -119,6 +119,16 @@ func (s *Server) ResolveOrCreateUser(ctx context.Context, req *usersv1.ResolveOr
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if created {
+		_, err = s.identityClient.RegisterIdentity(ctx, &identityv1.RegisterIdentityRequest{
+			IdentityId:   user.Meta.ID.String(),
+			IdentityType: identityv1.IdentityType_IDENTITY_TYPE_USER,
+		})
+		if err != nil {
+			_ = s.store.DeleteUser(ctx, user.Meta.ID)
+			return nil, status.Errorf(codes.Internal, "register identity: %v", err)
+		}
+	}
 	return &usersv1.ResolveOrCreateUserResponse{User: toProtoUser(user), Created: created}, nil
 }
 


### PR DESCRIPTION
## Summary
- register identities when ResolveOrCreateUser creates a user
- rollback user creation on identity registration failures

## Testing
- buf generate buf.build/agynio/api --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1
- go test ./...
- go vet ./...
- go build ./...

Refs #13