### PR TITLE
fix(migrations): cleanup ghost entry, expand immutability policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,21 @@
 # Contributing
 
-## Database migrations
+## Database Migrations
 
-- Migration files in `migrations/` are immutable once merged or released.
-- Do not edit, rename, or reorder existing migrations.
-- If behavior must change, add a new migration with the next sequence number.
+Migration files in `migrations/` use a filename-based runner (`internal/db/migrate.go`). Each file is tracked by **filename** in `schema_migrations`. All migrations run in a single transaction.
+
+### Rules
+
+1. **Immutable once merged.** Do not edit, rename, or reorder existing migration files. The filename is the version key — renaming creates a new version that will be applied to databases that already ran the original.
+
+2. **Additive only.** Schema changes to existing tables require a new file with the next sequence number. Never modify an existing migration to add or change columns.
+
+3. **Idempotent DDL where cross-version upgrades are possible.** If a migration may run against a database that already has the described state (e.g., column added by a mutated earlier migration), use `IF NOT EXISTS` / `IF EXISTS` guards.
+
+4. **No data mutations.** Schema migrations must not contain `INSERT`, `UPDATE`, or `DELETE` on application tables.
+
+### History
+
+- `0001_init.sql` was mutated (replaced `nickname` column with `email`) before v0.1.0 and is present in all released tags. This cannot be reverted.
+- `0003_add_nickname.sql` was renamed to `0003_add_email.sql` in v0.5.0. The `IF NOT EXISTS` guard was added post-v0.5.0 (`2082a87`).
+- `0005_cleanup_ghost_migration.sql` removes the ghost `0003_add_nickname.sql` entry from databases that upgraded through v0.3.0–v0.4.1.

--- a/migrations/0005_cleanup_ghost_migration.sql
+++ b/migrations/0005_cleanup_ghost_migration.sql
@@ -1,0 +1,4 @@
+-- Remove ghost schema_migrations entry left by the 0003 filename rename.
+-- Databases upgraded from v0.3.0–v0.4.1 (which had 0003_add_nickname.sql)
+-- to v0.5.0+ (which has 0003_add_email.sql) retain the old entry.
+DELETE FROM schema_migrations WHERE version = '0003_add_nickname.sql';


### PR DESCRIPTION
## Summary

Addresses migration hygiene issues discovered during the CrashLoopBackOff investigation.

### Problem

Databases that ran v0.3.0–v0.4.1 (which had `0003_add_nickname.sql`) and then upgraded to v0.5.0+ (where the file was renamed to `0003_add_email.sql`) retain a ghost entry `0003_add_nickname.sql` in `schema_migrations`. The DDL failure on upgrade was fixed in `2082a87` (`IF NOT EXISTS`), but the ghost entry remains.

### Changes

1. **`migrations/0005_cleanup_ghost_migration.sql`** — deletes the ghost `0003_add_nickname.sql` entry from `schema_migrations` if present. No-op on fresh installs.

2. **`CONTRIBUTING.md`** — expanded migration policy:
   - Immutable once merged (filename = version key)
   - Additive only (new file for any change)
   - Idempotent DDL where cross-version upgrades are possible
   - No data mutations in schema migrations
   - Historical record of the 0001/0003 mutations for context

### Why not revert 0001_init.sql?

`0001_init.sql` was mutated (replaced `nickname` with `email`) before v0.1.0. Every released tag has the mutated version. Reverting would break fresh installs since `0003_add_email.sql` adds the `nickname` column (not `email`). The mutation is documented in CONTRIBUTING.md as a historical record.

### Release

After merge, tag `v0.5.1` and bump `users_chart_version` in `agynio/architecture` bootstrap to `0.5.1`.