### PR TITLE
feat(users): add username support

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,4 +1,4 @@
 version: v1
 
 deps:
-  - buf.build/agynio/api
+  - buf.build/agynio/api:74e093945d7343239e9933d5de061836

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -21,6 +21,7 @@ func toProtoUser(user store.User) *usersv1.User {
 		Name:        user.Name,
 		Email:       user.Email,
 		Nickname:    user.Nickname,
+		Username:    user.Username,
 		PhotoUrl:    user.PhotoURL,
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -123,10 +123,7 @@ func (s *Server) ResolveOrCreateUser(ctx context.Context, req *usersv1.ResolveOr
 		return nil, status.Error(codes.InvalidArgument, "oidc_subject must be provided")
 	}
 	baseUsername := deriveUsernameBase(req.GetPreferredUsername(), req.GetEmail(), req.GetName(), oidcSubject)
-	candidates, err := usernameCandidates(baseUsername)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "derive username: %v", err)
-	}
+	iterator := newUsernameCandidateIterator(baseUsername)
 
 	input := store.UserInput{
 		OIDCSubject: oidcSubject,
@@ -134,7 +131,14 @@ func (s *Server) ResolveOrCreateUser(ctx context.Context, req *usersv1.ResolveOr
 		Email:       req.GetEmail(),
 		PhotoURL:    req.GetPhotoUrl(),
 	}
-	for _, candidate := range candidates {
+	for {
+		candidate, ok, err := iterator.Next()
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "derive username: %v", err)
+		}
+		if !ok {
+			return nil, status.Error(codes.Internal, "allocate username")
+		}
 		input.Username = candidate
 		user, created, err := s.store.ResolveOrCreateUser(ctx, input)
 		if err != nil {
@@ -155,7 +159,6 @@ func (s *Server) ResolveOrCreateUser(ctx context.Context, req *usersv1.ResolveOr
 		}
 		return &usersv1.ResolveOrCreateUserResponse{User: toProtoUser(user), Created: created}, nil
 	}
-	return nil, status.Error(codes.Internal, "allocate username")
 }
 
 func (s *Server) GetUser(ctx context.Context, req *usersv1.GetUserRequest) (*usersv1.GetUserResponse, error) {
@@ -608,12 +611,16 @@ func (s *Server) CreateUser(ctx context.Context, req *usersv1.CreateUserRequest)
 		}
 	} else {
 		baseUsername := deriveUsernameBase("", "", req.GetName(), oidcSubject)
-		candidates, err := usernameCandidates(baseUsername)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "derive username: %v", err)
-		}
+		iterator := newUsernameCandidateIterator(baseUsername)
 		created := false
-		for _, candidate := range candidates {
+		for {
+			candidate, ok, err := iterator.Next()
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "derive username: %v", err)
+			}
+			if !ok {
+				return nil, status.Error(codes.Internal, "allocate username")
+			}
 			input.Username = candidate
 			user, err = s.store.CreateUser(ctx, input)
 			if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -122,26 +122,40 @@ func (s *Server) ResolveOrCreateUser(ctx context.Context, req *usersv1.ResolveOr
 	if oidcSubject == "" {
 		return nil, status.Error(codes.InvalidArgument, "oidc_subject must be provided")
 	}
-	user, created, err := s.store.ResolveOrCreateUser(ctx, store.UserInput{
+	baseUsername := deriveUsernameBase(req.GetPreferredUsername(), req.GetEmail(), req.GetName(), oidcSubject)
+	candidates, err := usernameCandidates(baseUsername)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "derive username: %v", err)
+	}
+
+	input := store.UserInput{
 		OIDCSubject: oidcSubject,
 		Name:        req.GetName(),
 		Email:       req.GetEmail(),
 		PhotoURL:    req.GetPhotoUrl(),
-	})
-	if err != nil {
-		return nil, toStatusError(err)
 	}
-	if created {
-		_, err = s.identityClient.RegisterIdentity(ctx, &identityv1.RegisterIdentityRequest{
-			IdentityId:   user.Meta.ID.String(),
-			IdentityType: identityv1.IdentityType_IDENTITY_TYPE_USER,
-		})
+	for _, candidate := range candidates {
+		input.Username = candidate
+		user, created, err := s.store.ResolveOrCreateUser(ctx, input)
 		if err != nil {
-			_ = s.store.DeleteUser(ctx, user.Meta.ID)
-			return nil, status.Errorf(codes.Internal, "register identity: %v", err)
+			if isAlreadyExists(err, "username") {
+				continue
+			}
+			return nil, toStatusError(err)
 		}
+		if created {
+			_, err = s.identityClient.RegisterIdentity(ctx, &identityv1.RegisterIdentityRequest{
+				IdentityId:   user.Meta.ID.String(),
+				IdentityType: identityv1.IdentityType_IDENTITY_TYPE_USER,
+			})
+			if err != nil {
+				_ = s.store.DeleteUser(ctx, user.Meta.ID)
+				return nil, status.Errorf(codes.Internal, "register identity: %v", err)
+			}
+		}
+		return &usersv1.ResolveOrCreateUserResponse{User: toProtoUser(user), Created: created}, nil
 	}
-	return &usersv1.ResolveOrCreateUserResponse{User: toProtoUser(user), Created: created}, nil
+	return nil, status.Error(codes.Internal, "allocate username")
 }
 
 func (s *Server) GetUser(ctx context.Context, req *usersv1.GetUserRequest) (*usersv1.GetUserResponse, error) {
@@ -217,7 +231,7 @@ func (s *Server) UpdateUser(ctx context.Context, req *usersv1.UpdateUserRequest)
 			return nil, status.Errorf(codes.InvalidArgument, "cluster_role: %v", err)
 		}
 	}
-	if req.Name == nil && req.Email == nil && req.Nickname == nil && req.PhotoUrl == nil && req.ClusterRole == nil {
+	if req.Name == nil && req.Email == nil && req.Nickname == nil && req.PhotoUrl == nil && req.ClusterRole == nil && req.Username == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
 	}
 
@@ -241,6 +255,14 @@ func (s *Server) UpdateUser(ctx context.Context, req *usersv1.UpdateUserRequest)
 	if req.PhotoUrl != nil {
 		value := req.GetPhotoUrl()
 		update.PhotoURL = &value
+		updateUser = true
+	}
+	if req.Username != nil {
+		value := req.GetUsername()
+		if err := validateUsername(value); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "username: %v", err)
+		}
+		update.Username = &value
 		updateUser = true
 	}
 
@@ -470,6 +492,74 @@ func (s *Server) GetMe(ctx context.Context, _ *usersv1.GetMeRequest) (*usersv1.G
 	return &usersv1.GetMeResponse{User: toProtoUser(user), ClusterRole: clusterRole}, nil
 }
 
+func (s *Server) UpdateMe(ctx context.Context, req *usersv1.UpdateMeRequest) (*usersv1.UpdateMeResponse, error) {
+	identityID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+	if req.Name == nil && req.Username == nil {
+		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
+	}
+
+	update := store.UserUpdate{}
+	if req.Name != nil {
+		value := req.GetName()
+		update.Name = &value
+	}
+	if req.Username != nil {
+		value := req.GetUsername()
+		if err := validateUsername(value); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "username: %v", err)
+		}
+		update.Username = &value
+	}
+
+	user, err := s.store.UpdateUser(ctx, identityID, update)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	clusterRole, err := s.resolveClusterRole(ctx, identityID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	return &usersv1.UpdateMeResponse{User: toProtoUser(user), ClusterRole: clusterRole}, nil
+}
+
+func (s *Server) SearchUsers(ctx context.Context, req *usersv1.SearchUsersRequest) (*usersv1.SearchUsersResponse, error) {
+	if _, err := identityIDFromContext(ctx); err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+	prefix := req.GetPrefix()
+	if err := validateUsernamePrefix(prefix); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "prefix: %v", err)
+	}
+	limit := req.GetLimit()
+	if limit == 0 {
+		limit = usernameSearchDefault
+	}
+	if limit < 0 {
+		return nil, status.Error(codes.InvalidArgument, "limit must be positive")
+	}
+	if limit > usernameSearchMax {
+		return nil, status.Errorf(codes.InvalidArgument, "limit must be <= %d", usernameSearchMax)
+	}
+
+	entries, err := s.store.SearchUsers(ctx, prefix, limit)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	protoEntries := make([]*usersv1.UserDirectoryEntry, 0, len(entries))
+	for _, entry := range entries {
+		protoEntries = append(protoEntries, &usersv1.UserDirectoryEntry{
+			IdentityId: entry.IdentityID.String(),
+			Username:   entry.Username,
+			Name:       entry.Name,
+			PhotoUrl:   entry.PhotoURL,
+		})
+	}
+	return &usersv1.SearchUsersResponse{Users: protoEntries}, nil
+}
+
 func (s *Server) ListUsers(ctx context.Context, req *usersv1.ListUsersRequest) (*usersv1.ListUsersResponse, error) {
 	if _, err := s.requireClusterAdmin(ctx); err != nil {
 		return nil, err
@@ -498,14 +588,46 @@ func (s *Server) CreateUser(ctx context.Context, req *usersv1.CreateUserRequest)
 		return nil, status.Errorf(codes.InvalidArgument, "cluster_role: %v", err)
 	}
 
-	user, err := s.store.CreateUser(ctx, store.UserInput{
+	input := store.UserInput{
 		OIDCSubject: oidcSubject,
 		Name:        req.GetName(),
 		Nickname:    req.GetNickname(),
 		PhotoURL:    req.GetPhotoUrl(),
-	})
-	if err != nil {
-		return nil, toStatusError(err)
+	}
+	var user store.User
+	var err error
+	if req.Username != nil {
+		value := req.GetUsername()
+		if err := validateUsername(value); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "username: %v", err)
+		}
+		input.Username = value
+		user, err = s.store.CreateUser(ctx, input)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+	} else {
+		baseUsername := deriveUsernameBase("", "", req.GetName(), oidcSubject)
+		candidates, err := usernameCandidates(baseUsername)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "derive username: %v", err)
+		}
+		created := false
+		for _, candidate := range candidates {
+			input.Username = candidate
+			user, err = s.store.CreateUser(ctx, input)
+			if err != nil {
+				if isAlreadyExists(err, "username") {
+					continue
+				}
+				return nil, toStatusError(err)
+			}
+			created = true
+			break
+		}
+		if !created {
+			return nil, status.Error(codes.Internal, "allocate username")
+		}
 	}
 
 	_, err = s.identityClient.RegisterIdentity(ctx, &identityv1.RegisterIdentityRequest{
@@ -624,4 +746,12 @@ func toStatusError(err error) error {
 		return status.Error(codes.AlreadyExists, exists.Error())
 	}
 	return status.Errorf(codes.Internal, "internal error: %v", err)
+}
+
+func isAlreadyExists(err error, resource string) bool {
+	var exists *store.AlreadyExistsError
+	if !errors.As(err, &exists) {
+		return false
+	}
+	return exists.Resource == resource
 }

--- a/internal/server/username.go
+++ b/internal/server/username.go
@@ -107,21 +107,39 @@ func emailLocalPart(email string) string {
 	return parts[0]
 }
 
-func usernameCandidates(base string) ([]string, error) {
-	candidates := make([]string, 0, 1+(usernameNumericSuffixMax-1)+usernameRandomSuffixTries)
-	candidates = append(candidates, base)
-	for i := 2; i <= usernameNumericSuffixMax; i++ {
-		suffix := fmt.Sprintf("-%d", i)
-		candidates = append(candidates, usernameWithSuffix(base, suffix))
+type usernameCandidateIterator struct {
+	base            string
+	nextIndex       int
+	randomGenerated int
+	randomSuffix    func(int) (string, error)
+}
+
+func newUsernameCandidateIterator(base string) *usernameCandidateIterator {
+	return &usernameCandidateIterator{
+		base:         base,
+		randomSuffix: randomUsernameSuffix,
 	}
-	for i := 0; i < usernameRandomSuffixTries; i++ {
-		suffix, err := randomUsernameSuffix(usernameRandomSuffixLen)
+}
+
+func (iter *usernameCandidateIterator) Next() (string, bool, error) {
+	if iter.nextIndex == 0 {
+		iter.nextIndex++
+		return iter.base, true, nil
+	}
+	if iter.nextIndex < usernameNumericSuffixMax {
+		suffix := fmt.Sprintf("-%d", iter.nextIndex+1)
+		iter.nextIndex++
+		return usernameWithSuffix(iter.base, suffix), true, nil
+	}
+	if iter.randomGenerated < usernameRandomSuffixTries {
+		suffix, err := iter.randomSuffix(usernameRandomSuffixLen)
 		if err != nil {
-			return nil, err
+			return "", false, err
 		}
-		candidates = append(candidates, usernameWithSuffix(base, "-"+suffix))
+		iter.randomGenerated++
+		return usernameWithSuffix(iter.base, "-"+suffix), true, nil
 	}
-	return candidates, nil
+	return "", false, nil
 }
 
 func usernameWithSuffix(base, suffix string) string {

--- a/internal/server/username.go
+++ b/internal/server/username.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"regexp"
+	"strings"
+)
+
+const (
+	usernameMaxLength         = 32
+	usernameSearchDefault     = 10
+	usernameSearchMax         = 20
+	usernameNumericSuffixMax  = 99
+	usernameRandomSuffixLen   = 4
+	usernameRandomSuffixTries = 5
+)
+
+var usernamePattern = regexp.MustCompile(`^[a-z0-9_-]+$`)
+
+func validateUsername(value string) error {
+	if value == "" {
+		return errors.New("value is required")
+	}
+	if len(value) > usernameMaxLength {
+		return fmt.Errorf("max length %d", usernameMaxLength)
+	}
+	if !usernamePattern.MatchString(value) {
+		return fmt.Errorf("must match %s", usernamePattern.String())
+	}
+	return nil
+}
+
+func validateUsernamePrefix(value string) error {
+	if value == "" {
+		return errors.New("value is required")
+	}
+	if len(value) > usernameMaxLength {
+		return fmt.Errorf("max length %d", usernameMaxLength)
+	}
+	if !usernamePattern.MatchString(value) {
+		return fmt.Errorf("must match %s", usernamePattern.String())
+	}
+	return nil
+}
+
+func normalizeUsernameCandidate(value string) string {
+	if value == "" {
+		return ""
+	}
+	lower := strings.ToLower(value)
+	var builder strings.Builder
+	builder.Grow(len(lower))
+	lastDash := false
+	for _, r := range lower {
+		isAllowed := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-'
+		if !isAllowed {
+			if lastDash {
+				continue
+			}
+			builder.WriteByte('-')
+			lastDash = true
+			continue
+		}
+		if r == '-' {
+			if lastDash {
+				continue
+			}
+			lastDash = true
+			builder.WriteRune(r)
+			continue
+		}
+		lastDash = false
+		builder.WriteRune(r)
+	}
+	normalized := strings.Trim(builder.String(), "-")
+	if len(normalized) > usernameMaxLength {
+		normalized = normalized[:usernameMaxLength]
+	}
+	return normalized
+}
+
+func deriveUsernameBase(preferredUsername, email, name, oidcSubject string) string {
+	for _, candidate := range []string{preferredUsername, emailLocalPart(email), name} {
+		normalized := normalizeUsernameCandidate(candidate)
+		if normalized != "" {
+			return normalized
+		}
+	}
+	return fallbackUsername(oidcSubject)
+}
+
+func fallbackUsername(oidcSubject string) string {
+	hash := sha256.Sum256([]byte(oidcSubject))
+	return fmt.Sprintf("user-%s", hex.EncodeToString(hash[:])[:8])
+}
+
+func emailLocalPart(email string) string {
+	if email == "" {
+		return ""
+	}
+	parts := strings.SplitN(email, "@", 2)
+	return parts[0]
+}
+
+func usernameCandidates(base string) ([]string, error) {
+	candidates := make([]string, 0, 1+(usernameNumericSuffixMax-1)+usernameRandomSuffixTries)
+	candidates = append(candidates, base)
+	for i := 2; i <= usernameNumericSuffixMax; i++ {
+		suffix := fmt.Sprintf("-%d", i)
+		candidates = append(candidates, usernameWithSuffix(base, suffix))
+	}
+	for i := 0; i < usernameRandomSuffixTries; i++ {
+		suffix, err := randomUsernameSuffix(usernameRandomSuffixLen)
+		if err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, usernameWithSuffix(base, "-"+suffix))
+	}
+	return candidates, nil
+}
+
+func usernameWithSuffix(base, suffix string) string {
+	maxBaseLength := usernameMaxLength - len(suffix)
+	trimmed := base
+	if len(trimmed) > maxBaseLength {
+		trimmed = trimmed[:maxBaseLength]
+		trimmed = strings.TrimRight(trimmed, "-")
+	}
+	return trimmed + suffix
+}
+
+func randomUsernameSuffix(length int) (string, error) {
+	const letters = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, length)
+	max := big.NewInt(int64(len(letters)))
+	for i := range b {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", err
+		}
+		b[i] = letters[n.Int64()]
+	}
+	return string(b), nil
+}

--- a/internal/server/username_test.go
+++ b/internal/server/username_test.go
@@ -1,0 +1,129 @@
+package server
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeUsernameCandidate(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "spaces and case",
+			input:    "Jane Doe",
+			expected: "jane-doe",
+		},
+		{
+			name:     "invalid characters collapse",
+			input:    "--Hello__World!!",
+			expected: "hello__world",
+		},
+		{
+			name:     "length limit",
+			input:    strings.Repeat("A", usernameMaxLength+5),
+			expected: strings.Repeat("a", usernameMaxLength),
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := normalizeUsernameCandidate(testCase.input)
+			if result != testCase.expected {
+				t.Fatalf("expected %q, got %q", testCase.expected, result)
+			}
+		})
+	}
+}
+
+func TestDeriveUsernameBase(t *testing.T) {
+	base := deriveUsernameBase("Preferred_Name", "jane@example.com", "Jane", "subject")
+	if base != "preferred_name" {
+		t.Fatalf("expected preferred_name, got %q", base)
+	}
+
+	base = deriveUsernameBase("", "Jane.Doe+Team@example.com", "Jane", "subject")
+	if base != "jane-doe-team" {
+		t.Fatalf("expected jane-doe-team, got %q", base)
+	}
+
+	base = deriveUsernameBase("", "", "Ada Lovelace", "subject")
+	if base != "ada-lovelace" {
+		t.Fatalf("expected ada-lovelace, got %q", base)
+	}
+
+	hash := sha256.Sum256([]byte("subject"))
+	expectedFallback := fmt.Sprintf("user-%s", hex.EncodeToString(hash[:])[:8])
+	base = deriveUsernameBase("", "", "", "subject")
+	if base != expectedFallback {
+		t.Fatalf("expected fallback %q, got %q", expectedFallback, base)
+	}
+}
+
+func TestUsernameCandidateIterator(t *testing.T) {
+	randomCalls := 0
+	iterator := &usernameCandidateIterator{
+		base: "alice",
+		randomSuffix: func(length int) (string, error) {
+			randomCalls++
+			return "r4nd", nil
+		},
+	}
+
+	candidate, ok, err := iterator.Next()
+	if err != nil || !ok {
+		t.Fatalf("expected initial candidate, err=%v ok=%v", err, ok)
+	}
+	if candidate != "alice" {
+		t.Fatalf("expected alice, got %q", candidate)
+	}
+
+	candidate, ok, err = iterator.Next()
+	if err != nil || !ok {
+		t.Fatalf("expected second candidate, err=%v ok=%v", err, ok)
+	}
+	if candidate != "alice-2" {
+		t.Fatalf("expected alice-2, got %q", candidate)
+	}
+
+	for i := 3; i <= usernameNumericSuffixMax; i++ {
+		candidate, ok, err = iterator.Next()
+		if err != nil || !ok {
+			t.Fatalf("expected numeric candidate %d, err=%v ok=%v", i, err, ok)
+		}
+	}
+
+	if candidate != fmt.Sprintf("alice-%d", usernameNumericSuffixMax) {
+		t.Fatalf("expected last numeric candidate, got %q", candidate)
+	}
+	if randomCalls != 0 {
+		t.Fatalf("expected no random calls before numeric exhausted, got %d", randomCalls)
+	}
+
+	candidate, ok, err = iterator.Next()
+	if err != nil || !ok {
+		t.Fatalf("expected random candidate, err=%v ok=%v", err, ok)
+	}
+	if candidate != "alice-r4nd" {
+		t.Fatalf("expected alice-r4nd, got %q", candidate)
+	}
+	if randomCalls != 1 {
+		t.Fatalf("expected 1 random call, got %d", randomCalls)
+	}
+}
+
+func TestUsernameWithSuffixTrims(t *testing.T) {
+	base := strings.Repeat("a", usernameMaxLength)
+	result := usernameWithSuffix(base, "-2")
+	if len(result) != usernameMaxLength {
+		t.Fatalf("expected length %d, got %d", usernameMaxLength, len(result))
+	}
+	if !strings.HasSuffix(result, "-2") {
+		t.Fatalf("expected suffix -2, got %q", result)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -437,7 +437,7 @@ func (s *Store) SearchUsers(ctx context.Context, prefix string, limit int32) ([]
 	pattern := escapeLikePattern(prefix) + "%"
 	rows, err := s.pool.Query(ctx,
 		`SELECT identity_id, username, name, photo_url FROM users
-		WHERE username IS NOT NULL AND username <> '' AND username LIKE $1 ESCAPE '\\'
+		WHERE username IS NOT NULL AND username <> '' AND username LIKE $1
 		ORDER BY (username = $2) DESC, username ASC
 		LIMIT $3`,
 		pattern,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	userColumns     = `identity_id, oidc_subject, name, email, nickname, photo_url, created_at, updated_at`
+	userColumns     = `identity_id, oidc_subject, name, email, nickname, username, photo_url, created_at, updated_at`
 	apiTokenColumns = `id, identity_id, name, token_hash, token_prefix, expires_at, created_at, last_used_at`
 	deviceColumns   = `id, identity_id, name, openziti_identity_id, enrollment_jwt, status, created_at`
 )
@@ -31,6 +31,7 @@ type User struct {
 	Name        string
 	Email       string
 	Nickname    string
+	Username    string
 	PhotoURL    string
 }
 
@@ -39,6 +40,7 @@ type UserInput struct {
 	Name        string
 	Email       string
 	Nickname    string
+	Username    string
 	PhotoURL    string
 }
 
@@ -46,12 +48,20 @@ type UserUpdate struct {
 	Name     *string
 	Email    *string
 	Nickname *string
+	Username *string
 	PhotoURL *string
 }
 
 type UserListResult struct {
 	Users      []User
 	NextCursor *PageCursor
+}
+
+type UserDirectoryEntry struct {
+	IdentityID uuid.UUID
+	Username   string
+	Name       string
+	PhotoURL   string
 }
 
 type APIToken struct {
@@ -112,19 +122,37 @@ func New(pool *pgxpool.Pool) *Store {
 
 func scanUser(row pgx.Row) (User, error) {
 	var user User
+	var username pgtype.Text
 	if err := row.Scan(
 		&user.Meta.ID,
 		&user.OIDCSubject,
 		&user.Name,
 		&user.Email,
 		&user.Nickname,
+		&username,
 		&user.PhotoURL,
 		&user.Meta.CreatedAt,
 		&user.Meta.UpdatedAt,
 	); err != nil {
 		return User{}, err
 	}
+	if username.Valid {
+		user.Username = username.String
+	}
 	return user, nil
+}
+
+func scanUserDirectoryEntry(row pgx.Row) (UserDirectoryEntry, error) {
+	var entry UserDirectoryEntry
+	if err := row.Scan(
+		&entry.IdentityID,
+		&entry.Username,
+		&entry.Name,
+		&entry.PhotoURL,
+	); err != nil {
+		return UserDirectoryEntry{}, err
+	}
+	return entry, nil
 }
 
 func scanAPIToken(row pgx.Row) (APIToken, error) {
@@ -198,32 +226,40 @@ func (s *Store) ResolveOrCreateUser(ctx context.Context, input UserInput) (User,
 
 	identityID := uuid.New()
 	row = s.pool.QueryRow(ctx,
-		fmt.Sprintf(`INSERT INTO users (identity_id, oidc_subject, name, email, nickname, photo_url)
-        VALUES ($1, $2, $3, $4, $5, $6)
+		fmt.Sprintf(`INSERT INTO users (identity_id, oidc_subject, name, email, nickname, username, photo_url)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
         RETURNING %s`, userColumns),
 		identityID,
 		input.OIDCSubject,
 		input.Name,
 		input.Email,
 		input.Nickname,
+		input.Username,
 		input.PhotoURL,
 	)
 	user, err = scanUser(row)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			row = s.pool.QueryRow(ctx,
-				fmt.Sprintf(`SELECT %s FROM users WHERE oidc_subject = $1`, userColumns),
-				input.OIDCSubject,
-			)
-			user, err = scanUser(row)
-			if err != nil {
-				if errors.Is(err, pgx.ErrNoRows) {
-					return User{}, false, NotFound("user")
+			switch pgErr.ConstraintName {
+			case "users_username_idx":
+				return User{}, false, AlreadyExists("username")
+			case "users_oidc_subject_idx":
+				row = s.pool.QueryRow(ctx,
+					fmt.Sprintf(`SELECT %s FROM users WHERE oidc_subject = $1`, userColumns),
+					input.OIDCSubject,
+				)
+				user, err = scanUser(row)
+				if err != nil {
+					if errors.Is(err, pgx.ErrNoRows) {
+						return User{}, false, NotFound("user")
+					}
+					return User{}, false, err
 				}
-				return User{}, false, err
+				return user, false, nil
+			default:
+				return User{}, false, AlreadyExists("user")
 			}
-			return user, false, nil
 		}
 		return User{}, false, err
 	}
@@ -236,21 +272,29 @@ func (s *Store) ResolveOrCreateUser(ctx context.Context, input UserInput) (User,
 func (s *Store) CreateUser(ctx context.Context, input UserInput) (User, error) {
 	identityID := uuid.New()
 	row := s.pool.QueryRow(ctx,
-		fmt.Sprintf(`INSERT INTO users (identity_id, oidc_subject, name, email, nickname, photo_url)
-        VALUES ($1, $2, $3, $4, $5, $6)
+		fmt.Sprintf(`INSERT INTO users (identity_id, oidc_subject, name, email, nickname, username, photo_url)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
         RETURNING %s`, userColumns),
 		identityID,
 		input.OIDCSubject,
 		input.Name,
 		input.Email,
 		input.Nickname,
+		input.Username,
 		input.PhotoURL,
 	)
 	user, err := scanUser(row)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			return User{}, AlreadyExists("user")
+			switch pgErr.ConstraintName {
+			case "users_username_idx":
+				return User{}, AlreadyExists("username")
+			case "users_oidc_subject_idx":
+				return User{}, AlreadyExists("user")
+			default:
+				return User{}, AlreadyExists("user")
+			}
 		}
 		return User{}, err
 	}
@@ -331,6 +375,9 @@ func (s *Store) UpdateUser(ctx context.Context, id uuid.UUID, update UserUpdate)
 	if update.Nickname != nil {
 		builder.add("nickname", *update.Nickname)
 	}
+	if update.Username != nil {
+		builder.add("username", *update.Username)
+	}
 	if update.PhotoURL != nil {
 		builder.add("photo_url", *update.PhotoURL)
 	}
@@ -344,6 +391,13 @@ func (s *Store) UpdateUser(ctx context.Context, id uuid.UUID, update UserUpdate)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return User{}, NotFound("user")
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			if pgErr.ConstraintName == "users_username_idx" {
+				return User{}, AlreadyExists("username")
+			}
+			return User{}, AlreadyExists("user")
 		}
 		return User{}, err
 	}
@@ -376,6 +430,34 @@ func (s *Store) ListUsers(ctx context.Context, pageSize int32, cursor *PageCurso
 		return UserListResult{}, err
 	}
 	return UserListResult{Users: users, NextCursor: nextCursor}, nil
+}
+
+func (s *Store) SearchUsers(ctx context.Context, prefix string, limit int32) ([]UserDirectoryEntry, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT identity_id, username, name, photo_url FROM users
+        WHERE username IS NOT NULL AND username <> '' AND username LIKE $1 || '%'
+        ORDER BY (username = $1) DESC, username ASC
+        LIMIT $2`,
+		prefix,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	entries := []UserDirectoryEntry{}
+	for rows.Next() {
+		entry, err := scanUserDirectoryEntry(rows)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return entries, nil
 }
 
 func (s *Store) CreateAPIToken(ctx context.Context, input CreateAPITokenInput) (APIToken, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -433,11 +434,13 @@ func (s *Store) ListUsers(ctx context.Context, pageSize int32, cursor *PageCurso
 }
 
 func (s *Store) SearchUsers(ctx context.Context, prefix string, limit int32) ([]UserDirectoryEntry, error) {
+	pattern := escapeLikePattern(prefix) + "%"
 	rows, err := s.pool.Query(ctx,
 		`SELECT identity_id, username, name, photo_url FROM users
-        WHERE username IS NOT NULL AND username <> '' AND username LIKE $1 || '%'
-        ORDER BY (username = $1) DESC, username ASC
-        LIMIT $2`,
+		WHERE username IS NOT NULL AND username <> '' AND username LIKE $1 ESCAPE '\\'
+		ORDER BY (username = $2) DESC, username ASC
+		LIMIT $3`,
+		pattern,
 		prefix,
 		limit,
 	)
@@ -458,6 +461,11 @@ func (s *Store) SearchUsers(ctx context.Context, prefix string, limit int32) ([]
 		return nil, err
 	}
 	return entries, nil
+}
+
+func escapeLikePattern(value string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return replacer.Replace(value)
 }
 
 func (s *Store) CreateAPIToken(ctx context.Context, input CreateAPITokenInput) (APIToken, error) {

--- a/migrations/0005_add_username.sql
+++ b/migrations/0005_add_username.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users ADD COLUMN IF NOT EXISTS username TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS users_username_idx ON users (username) WHERE username IS NOT NULL;


### PR DESCRIPTION
## Summary
- add username column and unique search entries in the store
- implement username derivation/collision handling and profile updates
- add UpdateMe and SearchUsers RPCs

## Testing
- buf generate buf.build/agynio/api:74e093945d7343239e9933d5de061836 --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1
- go vet ./...
- go test ./...

Refs #140