### PR TITLE
fix(devspace): find the pod by name, not by release

### DIFF
--- a/charts/users/values.yaml
+++ b/charts/users/values.yaml
@@ -91,6 +91,10 @@ env:
     value: "users-group-sync"
   - name: GROUP_SYNC_RECONCILIATION_INTERVAL
     value: "60s"
+  # Restricts the one-shot first-admin claim to this verified email address.
+  # Empty lets the first sign-in take it.
+  - name: FIRST_ADMIN_EMAIL
+    value: ""
 envFrom: []
 extraEnvVars: []
 extraEnvVarsCM: ""

--- a/cmd/users-service/main.go
+++ b/cmd/users-service/main.go
@@ -85,6 +85,7 @@ func run() error {
 		identityv1.NewIdentityServiceClient(identityConn),
 		zitimanagementv1.NewZitiManagementServiceClient(zitiConn),
 		groupsv1.NewGroupsServiceClient(groupsConn),
+		server.WithFirstAdminEmail(cfg.FirstAdminEmail),
 	)
 	usersv1.RegisterUsersServiceServer(grpcServer, serverInstance)
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -155,7 +155,6 @@ dev:
     namespace: ${USERS_NAMESPACE}
     labelSelector:
       app.kubernetes.io/name: users
-      app.kubernetes.io/instance: users
     containers:
       users:
         container: users

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	NATSURL                string
 	GroupSyncDurable       string
 	ReconciliationInterval time.Duration
+	FirstAdminEmail        string
 }
 
 func FromEnv() (Config, error) {
@@ -61,5 +62,7 @@ func FromEnv() (Config, error) {
 		return Config{}, fmt.Errorf("GROUP_SYNC_RECONCILIATION_INTERVAL: %w", err)
 	}
 	cfg.ReconciliationInterval = duration
+	// Optional. Unset means the first sign-in takes cluster admin.
+	cfg.FirstAdminEmail = os.Getenv("FIRST_ADMIN_EMAIL")
 	return cfg, nil
 }

--- a/internal/server/first_admin.go
+++ b/internal/server/first_admin.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	usersv1 "github.com/agynio/users/.gen/go/agynio/api/users/v1"
+	"github.com/agynio/users/internal/store"
+)
+
+// WithFirstAdminEmail restricts the first-admin claim to the holder of this
+// email address. Unset, the first sign-in wins — the right default for a local
+// cluster nobody else can reach.
+func WithFirstAdminEmail(email string) Option {
+	return func(s *Server) {
+		s.firstAdminEmail = strings.TrimSpace(email)
+	}
+}
+
+// claimFirstAdmin grants cluster admin to a just-provisioned user when the
+// claim is still open and this claimant is permitted to take it.
+//
+// The claim is marked before the tuple is written. The two cannot share a
+// transaction — one is Postgres, the other OpenFGA — so one of them has to go
+// first, and the orders fail differently. Marking first can lose the grant and
+// leave a cluster with no admin, which an operator can see and repair. Writing
+// first can leave a granted tuple behind a claim that is still open, and the
+// next sign-in would then take the claim as well: two cluster admins, neither
+// of them wrong, and nothing to indicate it happened.
+func (s *Server) claimFirstAdmin(ctx context.Context, user store.User, emailVerified bool) error {
+	if !s.mayClaimFirstAdmin(user.Email, emailVerified) {
+		return nil
+	}
+	claimed, err := s.store.ClaimFirstAdmin(ctx, user.Meta.ID)
+	if err != nil {
+		return fmt.Errorf("claim first admin: %w", err)
+	}
+	if !claimed {
+		return nil
+	}
+	if err := s.syncClusterRole(ctx, user.Meta.ID, usersv1.ClusterRole_CLUSTER_ROLE_ADMIN); err != nil {
+		return fmt.Errorf("grant cluster admin: %w", err)
+	}
+	return nil
+}
+
+// mayClaimFirstAdmin reports whether these email claims satisfy the configured
+// restriction. A configured address needs the IdP to vouch for it: without
+// email_verified, anyone who can register with the IdP under the operator's
+// address would take the cluster.
+func (s *Server) mayClaimFirstAdmin(email string, emailVerified bool) bool {
+	if s.firstAdminEmail == "" {
+		return true
+	}
+	if !emailVerified {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(email), s.firstAdminEmail)
+}

--- a/internal/server/first_admin_test.go
+++ b/internal/server/first_admin_test.go
@@ -1,0 +1,173 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	usersv1 "github.com/agynio/users/.gen/go/agynio/api/users/v1"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestFirstSignInTakesClusterAdminWhenUnrestricted(t *testing.T) {
+	authorization := &fakeAuthorizationClient{}
+	server := newFirstAdminServer(newFakeUserStore(), authorization)
+
+	first, err := server.ResolveOrCreateUser(context.Background(), &usersv1.ResolveOrCreateUserRequest{
+		OidcSubject: "auth0|first",
+		Email:       "first@example.com",
+	})
+	require.NoError(t, err)
+	require.True(t, first.GetCreated())
+	require.Equal(t, []string{identityObject(first)}, authorization.clusterAdmins())
+
+	second, err := server.ResolveOrCreateUser(context.Background(), &usersv1.ResolveOrCreateUserRequest{
+		OidcSubject: "auth0|second",
+		Email:       "second@example.com",
+	})
+	require.NoError(t, err)
+	require.True(t, second.GetCreated())
+
+	returning, err := server.ResolveOrCreateUser(context.Background(), &usersv1.ResolveOrCreateUserRequest{
+		OidcSubject: "auth0|first",
+		Email:       "first@example.com",
+	})
+	require.NoError(t, err)
+	require.False(t, returning.GetCreated())
+
+	require.Equal(t, []string{identityObject(first)}, authorization.clusterAdmins())
+}
+
+func TestNonMatchingEmailLeavesTheClaimOpen(t *testing.T) {
+	authorization := &fakeAuthorizationClient{}
+	server := newFirstAdminServer(newFakeUserStore(), authorization, WithFirstAdminEmail("Admin@Example.com"))
+
+	other, err := server.ResolveOrCreateUser(context.Background(), &usersv1.ResolveOrCreateUserRequest{
+		OidcSubject:   "auth0|other",
+		Email:         "other@example.com",
+		EmailVerified: true,
+	})
+	require.NoError(t, err)
+	require.True(t, other.GetCreated())
+	require.Empty(t, authorization.clusterAdmins())
+
+	admin, err := server.ResolveOrCreateUser(context.Background(), &usersv1.ResolveOrCreateUserRequest{
+		OidcSubject:   "auth0|admin",
+		Email:         "admin@example.com",
+		EmailVerified: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{identityObject(admin)}, authorization.clusterAdmins())
+}
+
+func TestUnverifiedEmailNeverTakesTheClaim(t *testing.T) {
+	authorization := &fakeAuthorizationClient{}
+	server := newFirstAdminServer(newFakeUserStore(), authorization, WithFirstAdminEmail("admin@example.com"))
+
+	impostor, err := server.ResolveOrCreateUser(context.Background(), &usersv1.ResolveOrCreateUserRequest{
+		OidcSubject: "auth0|impostor",
+		Email:       "admin@example.com",
+	})
+	require.NoError(t, err)
+	require.True(t, impostor.GetCreated())
+	require.Empty(t, authorization.clusterAdmins())
+
+	admin, err := server.ResolveOrCreateUser(context.Background(), &usersv1.ResolveOrCreateUserRequest{
+		OidcSubject:   "auth0|admin",
+		Email:         "admin@example.com",
+		EmailVerified: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{identityObject(admin)}, authorization.clusterAdmins())
+}
+
+func TestConcurrentFirstSignInsProduceExactlyOneClusterAdmin(t *testing.T) {
+	authorization := &fakeAuthorizationClient{}
+	fakeStore := newFakeUserStore()
+	server := newFirstAdminServer(fakeStore, authorization)
+
+	const claimants = 8
+	var start sync.WaitGroup
+	var finished sync.WaitGroup
+	start.Add(1)
+	errs := make(chan error, claimants)
+	for index := range claimants {
+		finished.Add(1)
+		go func() {
+			defer finished.Done()
+			start.Wait()
+			_, err := server.ResolveOrCreateUser(context.Background(), &usersv1.ResolveOrCreateUserRequest{
+				OidcSubject: fmt.Sprintf("auth0|%d", index),
+				Email:       fmt.Sprintf("user-%d@example.com", index),
+			})
+			errs <- err
+		}()
+	}
+	start.Done()
+	finished.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Len(t, fakeStore.users, claimants)
+	require.Len(t, authorization.clusterAdmins(), 1)
+}
+
+func TestDeletingEveryClusterAdminDoesNotReopenTheClaim(t *testing.T) {
+	authorization := &fakeAuthorizationClient{}
+	server := newFirstAdminServer(newFakeUserStore(), authorization)
+
+	first, err := server.ResolveOrCreateUser(context.Background(), &usersv1.ResolveOrCreateUserRequest{
+		OidcSubject: "auth0|first",
+		Email:       "first@example.com",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{identityObject(first)}, authorization.clusterAdmins())
+
+	adminContext := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", uuid.NewString()))
+	_, err = server.DeleteUser(adminContext, &usersv1.DeleteUserRequest{
+		IdentityId: first.GetUser().GetMeta().GetId(),
+	})
+	require.NoError(t, err)
+	require.Empty(t, authorization.clusterAdmins())
+
+	next, err := server.ResolveOrCreateUser(context.Background(), &usersv1.ResolveOrCreateUserRequest{
+		OidcSubject: "auth0|next",
+		Email:       "next@example.com",
+	})
+	require.NoError(t, err)
+	require.True(t, next.GetCreated())
+	require.Empty(t, authorization.clusterAdmins())
+}
+
+func TestFailedGrantDoesNotHandTheClaimToTheNextSignIn(t *testing.T) {
+	authorization := &fakeAuthorizationClient{writeErr: fmt.Errorf("openfga unavailable")}
+	server := newFirstAdminServer(newFakeUserStore(), authorization)
+
+	_, err := server.ResolveOrCreateUser(context.Background(), &usersv1.ResolveOrCreateUserRequest{
+		OidcSubject: "auth0|first",
+		Email:       "first@example.com",
+	})
+	require.ErrorContains(t, err, "grant cluster admin")
+
+	authorization.writeErr = nil
+	next, err := server.ResolveOrCreateUser(context.Background(), &usersv1.ResolveOrCreateUserRequest{
+		OidcSubject: "auth0|next",
+		Email:       "next@example.com",
+	})
+	require.NoError(t, err)
+	require.True(t, next.GetCreated())
+	require.Empty(t, authorization.clusterAdmins())
+}
+
+func newFirstAdminServer(store userStore, authorization *fakeAuthorizationClient, options ...Option) *Server {
+	return NewWithGroups(store, authorization, &fakeIdentityClient{}, &fakeZitiManagementClient{}, nil, options...)
+}
+
+func identityObject(response *usersv1.ResolveOrCreateUserResponse) string {
+	return identityObjectPrefix + response.GetUser().GetMeta().GetId()
+}

--- a/internal/server/group_sync_test.go
+++ b/internal/server/group_sync_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -199,17 +200,51 @@ func mustMarshal(t *testing.T, message proto.Message) []byte {
 }
 
 type fakeUserStore struct {
-	users        []store.User
-	devices      map[uuid.UUID][]store.Device
-	createDevice store.Device
+	mu              sync.Mutex
+	users           []store.User
+	devices         map[uuid.UUID][]store.Device
+	createDevice    store.Device
+	firstAdminClaim *uuid.UUID
 }
 
 func newFakeUserStore() *fakeUserStore {
 	return &fakeUserStore{devices: map[uuid.UUID][]store.Device{}}
 }
 
-func (s *fakeUserStore) ResolveOrCreateUser(context.Context, store.UserInput) (store.User, bool, error) {
-	panic("unexpected ResolveOrCreateUser")
+func (s *fakeUserStore) ResolveOrCreateUser(_ context.Context, input store.UserInput) (store.User, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, user := range s.users {
+		if user.OIDCSubject == input.OIDCSubject {
+			return user, false, nil
+		}
+		if input.Username != "" && user.Username == input.Username {
+			return store.User{}, false, store.AlreadyExists("username")
+		}
+	}
+	user := store.User{
+		Meta:        store.EntityMeta{ID: uuid.New()},
+		OIDCSubject: input.OIDCSubject,
+		Name:        input.Name,
+		Email:       input.Email,
+		Nickname:    input.Nickname,
+		Username:    input.Username,
+		PhotoURL:    input.PhotoURL,
+	}
+	s.users = append(s.users, user)
+	return user, true, nil
+}
+
+// ClaimFirstAdmin stands in for the single-row primary key: whoever inserts
+// first takes the claim, and nothing reopens it.
+func (s *fakeUserStore) ClaimFirstAdmin(_ context.Context, identityID uuid.UUID) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.firstAdminClaim != nil {
+		return false, nil
+	}
+	s.firstAdminClaim = &identityID
+	return true, nil
 }
 
 func (s *fakeUserStore) CreateUser(context.Context, store.UserInput) (store.User, error) {
@@ -232,8 +267,16 @@ func (s *fakeUserStore) UpdateUser(context.Context, uuid.UUID, store.UserUpdate)
 	panic("unexpected UpdateUser")
 }
 
-func (s *fakeUserStore) DeleteUser(context.Context, uuid.UUID) error {
-	panic("unexpected DeleteUser")
+func (s *fakeUserStore) DeleteUser(_ context.Context, identityID uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for index, user := range s.users {
+		if user.Meta.ID == identityID {
+			s.users = append(s.users[:index], s.users[index+1:]...)
+			return nil
+		}
+	}
+	return store.NotFound("user")
 }
 
 func (s *fakeUserStore) ListUsers(_ context.Context, pageSize int32, cursor *store.PageCursor) (store.UserListResult, error) {
@@ -315,15 +358,55 @@ func (s *fakeUserStore) DeleteDevice(context.Context, uuid.UUID, uuid.UUID) (sto
 
 type fakeAuthorizationClient struct {
 	authorizationv1.UnimplementedAuthorizationServiceServer
-	objects []string
+	mu       sync.Mutex
+	objects  []string
+	writes   []*authorizationv1.WriteRequest
+	writeErr error
 }
 
 func (c *fakeAuthorizationClient) Check(context.Context, *authorizationv1.CheckRequest, ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
 	return &authorizationv1.CheckResponse{Allowed: true}, nil
 }
 
-func (c *fakeAuthorizationClient) Write(context.Context, *authorizationv1.WriteRequest, ...grpc.CallOption) (*authorizationv1.WriteResponse, error) {
+func (c *fakeAuthorizationClient) Write(_ context.Context, request *authorizationv1.WriteRequest, _ ...grpc.CallOption) (*authorizationv1.WriteResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.writeErr != nil {
+		return nil, c.writeErr
+	}
+	c.writes = append(c.writes, proto.Clone(request).(*authorizationv1.WriteRequest))
 	return &authorizationv1.WriteResponse{}, nil
+}
+
+// clusterAdmins replays the recorded tuple writes into the set of identities
+// that currently hold cluster admin.
+func (c *fakeAuthorizationClient) clusterAdmins() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	admins := []string{}
+	for _, request := range c.writes {
+		for _, tuple := range request.GetWrites() {
+			if isClusterAdminTuple(tuple) {
+				admins = append(admins, tuple.GetUser())
+			}
+		}
+		for _, tuple := range request.GetDeletes() {
+			if !isClusterAdminTuple(tuple) {
+				continue
+			}
+			for index, admin := range admins {
+				if admin == tuple.GetUser() {
+					admins = append(admins[:index], admins[index+1:]...)
+					break
+				}
+			}
+		}
+	}
+	return admins
+}
+
+func isClusterAdminTuple(tuple *authorizationv1.TupleKey) bool {
+	return tuple.GetRelation() == adminRelation && tuple.GetObject() == clusterObject
 }
 
 func (c *fakeAuthorizationClient) ListObjects(context.Context, *authorizationv1.ListObjectsRequest, ...grpc.CallOption) (*authorizationv1.ListObjectsResponse, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -33,7 +33,11 @@ type Server struct {
 	identityClient       identityv1.IdentityServiceClient
 	zitiManagementClient zitiManagementClient
 	groupsClient         groupsClient
+	firstAdminEmail      string
 }
+
+// Option adjusts optional Server behavior at construction.
+type Option func(*Server)
 
 type userStore interface {
 	ResolveOrCreateUser(context.Context, store.UserInput) (store.User, bool, error)
@@ -45,6 +49,7 @@ type userStore interface {
 	DeleteUser(context.Context, uuid.UUID) error
 	ListUsers(context.Context, int32, *store.PageCursor) (store.UserListResult, error)
 	SearchUsers(context.Context, string, int32) ([]store.UserDirectoryEntry, error)
+	ClaimFirstAdmin(context.Context, uuid.UUID) (bool, error)
 	CreateAPIToken(context.Context, store.CreateAPITokenInput) (store.APIToken, error)
 	ListAPITokens(context.Context, uuid.UUID) ([]store.APIToken, error)
 	RevokeAPIToken(context.Context, uuid.UUID, uuid.UUID) error
@@ -69,8 +74,9 @@ func New(
 	authorizationClient authorizationv1.AuthorizationServiceClient,
 	identityClient identityv1.IdentityServiceClient,
 	zitiManagementClient zitimanagementv1.ZitiManagementServiceClient,
+	options ...Option,
 ) *Server {
-	return NewWithGroups(store, authorizationClient, identityClient, zitiManagementClient, nil)
+	return NewWithGroups(store, authorizationClient, identityClient, zitiManagementClient, nil, options...)
 }
 
 func NewWithGroups(
@@ -79,14 +85,19 @@ func NewWithGroups(
 	identityClient identityv1.IdentityServiceClient,
 	zitiManagementClient zitiManagementClient,
 	groupsClient groupsClient,
+	options ...Option,
 ) *Server {
-	return &Server{
+	server := &Server{
 		store:                store,
 		authorizationClient:  authorizationClient,
 		identityClient:       identityClient,
 		zitiManagementClient: zitiManagementClient,
 		groupsClient:         groupsClient,
 	}
+	for _, option := range options {
+		option(server)
+	}
+	return server
 }
 
 func identityIDFromContext(ctx context.Context) (uuid.UUID, error) {
@@ -198,6 +209,12 @@ func (s *Server) ResolveOrCreateUser(ctx context.Context, req *usersv1.ResolveOr
 			if err != nil {
 				_ = s.store.DeleteUser(ctx, user.Meta.ID)
 				return nil, status.Errorf(codes.Internal, "register identity: %v", err)
+			}
+			if err := s.claimFirstAdmin(ctx, user, req.GetEmailVerified()); err != nil {
+				// The user is provisioned either way. Reporting the failure is
+				// what tells an operator their cluster has no admin, since the
+				// claim stays taken and no later sign-in will grant one.
+				return nil, status.Errorf(codes.Internal, "%v", err)
 			}
 		}
 		return &usersv1.ResolveOrCreateUserResponse{User: toProtoUser(user), Created: created}, nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -468,6 +468,21 @@ func escapeLikePattern(value string) string {
 	return replacer.Replace(value)
 }
 
+// ClaimFirstAdmin takes the one-shot first-admin claim for identityID and
+// reports whether this caller took it. The primary key admits a single row, so
+// concurrent claimants serialize on it and exactly one insert survives — the
+// losers block until the winner commits and then affect no rows.
+func (s *Store) ClaimFirstAdmin(ctx context.Context, identityID uuid.UUID) (bool, error) {
+	result, err := s.pool.Exec(ctx,
+		`INSERT INTO first_admin_claim (identity_id) VALUES ($1) ON CONFLICT DO NOTHING`,
+		identityID,
+	)
+	if err != nil {
+		return false, err
+	}
+	return result.RowsAffected() == 1, nil
+}
+
 func (s *Store) CreateAPIToken(ctx context.Context, input CreateAPITokenInput) (APIToken, error) {
 	row := s.pool.QueryRow(ctx,
 		fmt.Sprintf(`INSERT INTO user_api_tokens (identity_id, name, token_hash, token_prefix, expires_at)

--- a/migrations/0006_first_admin_claim.sql
+++ b/migrations/0006_first_admin_claim.sql
@@ -1,0 +1,8 @@
+-- The first-admin claim is its own record, not a count of cluster admins:
+-- deleting every admin must not reopen it. Deliberately without a foreign key
+-- to users, so deleting the claimant leaves the claim taken.
+CREATE TABLE first_admin_claim (
+    singleton   BOOLEAN     PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    identity_id UUID        NOT NULL,
+    claimed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
Deploying this service from source into the platform VM hangs with `DevSpace still couldn't find any Pods that match the selector`.

The `dev` selector paired `app.kubernetes.io/name` with `app.kubernetes.io/instance=<service>`. That held when every service was its own Helm release; the **agyn-platform umbrella** makes the instance label its own release name. Verified against a running VM: the pod carries `app.kubernetes.io/instance: agyn-platform`, so the old selector matches 0 pods and `name` alone matches 1.

The pod then starts and spins waiting for a binary the sync never delivers. Same fix as identity#14, apps#29, chat#33, notifications#36.