### PR TITLE
Treat an unchanged cluster role as synced

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -166,6 +166,13 @@ func (s *Server) syncClusterRole(ctx context.Context, identityID uuid.UUID, role
 		return fmt.Errorf("unsupported cluster role: %s", role.String())
 	}
 	_, err := s.authorizationClient.Write(ctx, request)
+	// The role already being what was asked for is convergence, not failure:
+	// this runs on every sign-in and from the declared administrators, so both
+	// reach a user who already holds it.
+	switch status.Code(err) {
+	case codes.AlreadyExists, codes.NotFound:
+		return nil
+	}
 	return err
 }
 


### PR DESCRIPTION
Companion to agynio/authorization#38.

`syncClusterRole` runs on every sign-in and from the declared cluster administrators, so it routinely reaches a user who already holds the role. It returned the write error verbatim, so granting a role someone already had failed the whole call — which is what stranded the declared administrator on the bundled VM:

    granting cluster admin: internal: sync cluster role: InvalidArgument
    cannot write a tuple which already exists

With Authorization now reporting a duplicate write as `AlreadyExists` and a missing delete as `NotFound`, both are treated as the desired state already holding.