### PR TITLE
Name the user when asking Groups for their memberships

### DIFF
--- a/internal/server/group_sync.go
+++ b/internal/server/group_sync.go
@@ -11,8 +11,14 @@ import (
 	zitimanagementv1 "github.com/agynio/users/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/agynio/users/internal/store"
 	"github.com/google/uuid"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 )
+
+// identityMetadataKey names the caller on a request. gRPC does not carry
+// incoming metadata onto outgoing calls, so a service that dials another on
+// behalf of someone has to say who that is.
+const identityMetadataKey = "x-identity-id"
 
 const (
 	groupMembershipAddedSubject   = "agyn.groups.membership.added"
@@ -54,6 +60,12 @@ func (s *Server) listUserGroups(ctx context.Context, userID uuid.UUID) ([]*group
 	if err != nil {
 		return nil, err
 	}
+	// Named as the user whose groups these are. Groups lets a caller read its
+	// own memberships outright and asks for organization membership otherwise,
+	// so this is both what the request means and the only identity the caller
+	// always has: reconciliation runs on a timer with no request behind it.
+	ctx = metadata.AppendToOutgoingContext(ctx, identityMetadataKey, userID.String())
+
 	groups := []*groupsv1.Group{}
 	for _, organizationID := range organizationIDs {
 		pageToken := ""

--- a/internal/server/group_sync_test.go
+++ b/internal/server/group_sync_test.go
@@ -179,6 +179,34 @@ func TestListUserGroupsPaginatesOrganizationsAndGroups(t *testing.T) {
 	require.Equal(t, "page-1", groups.requests[1].GetPageToken())
 }
 
+// Groups answers Unauthenticated without a caller, and gRPC does not carry a
+// server's incoming metadata onto the calls it makes. Reconciliation runs on a
+// timer with no request behind it at all, so naming the user is the only thing
+// that works on both paths -- and Groups lets a caller read its own
+// memberships, which is exactly what this is.
+func TestUserGroupRoleAttributesNamesTheUserToGroups(t *testing.T) {
+	userID := uuid.New()
+	orgID := uuid.New()
+	groupID := uuid.New().String()
+
+	groups := &fakeGroupsClient{groupsByOrg: map[string][]*groupsv1.Group{
+		orgID.String(): {{Meta: &groupsv1.EntityMeta{Id: groupID}}},
+	}}
+	server := NewWithGroups(
+		newFakeUserStore(),
+		&fakeAuthorizationClient{objects: []string{organizationObjectPrefix + orgID.String()}},
+		&fakeIdentityClient{},
+		&fakeZitiManagementClient{},
+		groups,
+	)
+
+	// Background context: no incoming request, nothing to forward.
+	attrs, err := server.userGroupRoleAttributes(context.Background(), userID)
+	require.NoError(t, err)
+	require.Equal(t, []string{groupRoleAttribute(groupID)}, attrs)
+	require.Equal(t, []string{userID.String()}, groups.callers)
+}
+
 func storeDevice(id uuid.UUID, userID uuid.UUID, name string, zitiIdentityID string) store.Device {
 	jwt := "jwt"
 	return store.Device{
@@ -469,9 +497,19 @@ type fakeGroupsClient struct {
 	groupsByOrg      map[string][]*groupsv1.Group
 	pagedGroupsByOrg map[string][][]*groupsv1.Group
 	requests         []*groupsv1.ListMemberGroupsRequest
+	// Groups reads the caller off the outgoing metadata, so a fake that only
+	// records the request cannot tell an authorized call from a rejected one.
+	callers []string
 }
 
-func (c *fakeGroupsClient) ListMemberGroups(_ context.Context, request *groupsv1.ListMemberGroupsRequest, _ ...grpc.CallOption) (*groupsv1.ListMemberGroupsResponse, error) {
+func (c *fakeGroupsClient) ListMemberGroups(ctx context.Context, request *groupsv1.ListMemberGroupsRequest, _ ...grpc.CallOption) (*groupsv1.ListMemberGroupsResponse, error) {
+	caller := ""
+	if md, ok := metadata.FromOutgoingContext(ctx); ok {
+		if values := md.Get("x-identity-id"); len(values) > 0 {
+			caller = values[0]
+		}
+	}
+	c.callers = append(c.callers, caller)
 	c.requests = append(c.requests, proto.Clone(request).(*groupsv1.ListMemberGroupsRequest))
 	if c.pagedGroupsByOrg != nil {
 		pages := c.pagedGroupsByOrg[request.GetOrganizationId()]


### PR DESCRIPTION
Adding a device in the Console fails with:

```
[internal] list user group memberships: list member groups:
rpc error: code = Unauthenticated desc = missing identity id
```

`listUserGroups` passes the incoming server context straight to `groupsClient.ListMemberGroups`. gRPC does not carry incoming metadata onto outgoing calls, so Groups sees no `x-identity-id` and rejects it.

It is not only the device button. `userGroupRoleAttributes` is also called by the device-role reconciliation loop, which has been failing every 60 seconds on the test VM since it came up:

```
01:24:21 group role reconciliation failed: list member groups: ... missing identity id
01:25:21 group role reconciliation failed: ... (once a minute, ever since)
```

**The fix** names the user whose groups are being read:

```go
ctx = metadata.AppendToOutgoingContext(ctx, identityMetadataKey, userID.String())
```

That is deliberate rather than convenient. Groups authorizes as:

```go
if !isCaller(ctx, memberID) {
    if err := s.requireOrganizationMember(ctx, organizationID); err != nil {
```

— a caller reading its own memberships is allowed outright. So the user is both what the request means and the only identity available on both paths: reconciliation runs on a timer with no request behind it, so there is nothing to forward there.

**Why nothing caught it.** `fakeGroupsClient.ListMemberGroups` took `_ context.Context` and discarded it, so the tests could not tell an authorized call from a rejected one. It now records the outgoing caller, and the new test fails without the fix:

```
--- FAIL: TestUserGroupRoleAttributesNamesTheUserToGroups
    expected: []string{"0dd15d36-..."}
    actual:   []string{""}
```