### PR TITLE
Report what a device is actually doing, not just pending

### DIFF
--- a/cmd/users-service/main.go
+++ b/cmd/users-service/main.go
@@ -90,6 +90,7 @@ func run() error {
 
 	serverInstance.StartGroupMembershipConsumerLoop(ctx, cfg.NATSURL, cfg.GroupSyncDurable)
 	serverInstance.StartGroupRoleReconciliation(ctx, cfg.ReconciliationInterval)
+	serverInstance.StartDeviceLivenessPolling(ctx, cfg.DeviceLivenessInterval)
 
 	lis, err := net.Listen("tcp", cfg.GRPCAddress)
 	if err != nil {

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -7,7 +7,11 @@ vars:
 functions:
   patch_deployment: |-
     echo "Patching users deployment for DevSpace..."
-    kubectl patch deployment users-users -n ${USERS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    # Its own release names the deployment users-users, the umbrella names it
+    # users. Look it up by label rather than guessing.
+    USERS_DEPLOYMENT="$(kubectl get deployment -n ${USERS_NAMESPACE} \
+      -l app.kubernetes.io/name=users -o jsonpath='{.items[0].metadata.name}')"
+    kubectl patch deployment "${USERS_DEPLOYMENT}" -n ${USERS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
       template:
         spec:
@@ -32,7 +36,16 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate buf.build/agynio/api --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1
+                  # .gen survives restarts in the synced volume; regenerating on every
+                  # crash-loop restart rate-limits us out of the BSR. The marker keys
+                  # on the command, not the module, so delete the pod after an api
+                  # publish to pick up new protos.
+                  GEN="buf generate buf.build/agynio/api --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/groups/v1"
+                  if [ "$(cat .gen/.gen-cmd 2>/dev/null)" != "$GEN" ]; then
+                    rm -rf .gen
+                    sh -c "$GEN"
+                    printf '%s' "$GEN" > .gen/.gen-cmd
+                  fi
                   exec go run ./cmd/users-service
               volumeMounts:
                 - name: data
@@ -56,6 +69,11 @@ functions:
                   type: RuntimeDefault
     EOF
     )"
+    # go run recompiles on every restart; the probes would kill the pod before
+    # the first build finishes. Nulling through a strategic merge tolerates
+    # them already being absent, so the patch stays re-runnable.
+    kubectl patch deployment "${USERS_DEPLOYMENT}" -n ${USERS_NAMESPACE} --type strategic --patch \
+      '{"spec":{"template":{"spec":{"containers":[{"name":"users","livenessProbe":null,"readinessProbe":null}]}}}}'
 
 deployments:
   e2e-runner:
@@ -74,8 +92,8 @@ deployments:
           app.kubernetes.io/name: users-e2e
 
 commands:
-  test:e2e: |-
-    devspace run-pipeline test:e2e $@
+  test-e2e: |-
+    devspace run-pipeline test-e2e $@
 
 pipelines:
   dev:
@@ -106,7 +124,7 @@ pipelines:
         stop_dev users
       fi
 
-  test:e2e:
+  test-e2e:
     run: |-
       create_deployments e2e-runner
       start_dev e2e-runner &
@@ -114,7 +132,7 @@ pipelines:
       exec_container \
         --label-selector "app.kubernetes.io/name=users-e2e" \
         -n ${USERS_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/groups/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       stop_dev e2e-runner
       purge_deployments e2e-runner
@@ -150,8 +168,6 @@ dev:
         logs:
           enabled: true
           lastLines: 200
-    ports:
-      - port: "50051"
 
   e2e-runner:
     namespace: ${USERS_NAMESPACE}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	NATSURL                string
 	GroupSyncDurable       string
 	ReconciliationInterval time.Duration
+	DeviceLivenessInterval time.Duration
 }
 
 func FromEnv() (Config, error) {
@@ -61,6 +62,14 @@ func FromEnv() (Config, error) {
 		return Config{}, fmt.Errorf("GROUP_SYNC_RECONCILIATION_INTERVAL: %w", err)
 	}
 	cfg.ReconciliationInterval = duration
+	deviceLivenessInterval := os.Getenv("DEVICE_LIVENESS_INTERVAL")
+	if deviceLivenessInterval == "" {
+		deviceLivenessInterval = "30s"
+	}
+	cfg.DeviceLivenessInterval, err = time.ParseDuration(deviceLivenessInterval)
+	if err != nil {
+		return Config{}, fmt.Errorf("DEVICE_LIVENESS_INTERVAL: %w", err)
+	}
 	// Optional. Unset means the first sign-in takes cluster admin.
 	return cfg, nil
 }

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"time"
+
 	usersv1 "github.com/agynio/users/.gen/go/agynio/api/users/v1"
 	"github.com/agynio/users/internal/store"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -57,6 +59,27 @@ func toProtoDevice(device store.Device) *usersv1.Device {
 		Name:               device.Name,
 		OpenzitiIdentityId: device.OpenZitiIdentityID,
 		Status:             toProtoDeviceStatus(device.Status),
+		Connectivity:       toProtoDeviceConnectivity(device.Connectivity),
+		EnrolledAt:         optionalTimestamp(device.EnrolledAt),
+		LastSeenAt:         optionalTimestamp(device.LastSeenAt),
+	}
+}
+
+func optionalTimestamp(value *time.Time) *timestamppb.Timestamp {
+	if value == nil {
+		return nil
+	}
+	return timestamppb.New(*value)
+}
+
+func toProtoDeviceConnectivity(connectivity store.DeviceConnectivity) usersv1.DeviceConnectivity {
+	switch connectivity {
+	case store.DeviceConnectivityOnline:
+		return usersv1.DeviceConnectivity_DEVICE_CONNECTIVITY_ONLINE
+	case store.DeviceConnectivityOffline:
+		return usersv1.DeviceConnectivity_DEVICE_CONNECTIVITY_OFFLINE
+	default:
+		panic("unsupported device connectivity: " + string(connectivity))
 	}
 }
 

--- a/internal/server/device_liveness.go
+++ b/internal/server/device_liveness.go
@@ -1,0 +1,116 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	zitimanagementv1 "github.com/agynio/users/.gen/go/agynio/api/ziti_management/v1"
+	"github.com/agynio/users/internal/store"
+)
+
+// Devices are written pending and only OpenZiti knows when the enrollment token
+// is redeemed, so without polling they stay pending forever.
+func (s *Server) StartDeviceLivenessPolling(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := s.PollDeviceLiveness(ctx); err != nil {
+					log.Printf("device liveness polling failed: %v", err)
+				}
+			}
+		}
+	}()
+}
+
+func (s *Server) PollDeviceLiveness(ctx context.Context) error {
+	pageToken := (*store.PageCursor)(nil)
+	for {
+		result, err := s.store.ListUsers(ctx, store.MaxListPageSize, pageToken)
+		if err != nil {
+			return fmt.Errorf("list users: %w", err)
+		}
+		for _, user := range result.Users {
+			devices, err := s.listAllUserDevices(ctx, user.Meta.ID)
+			if err != nil {
+				log.Printf("list devices for user %s failed: %v", user.Meta.ID, err)
+				continue
+			}
+			for _, device := range devices {
+				if err := s.pollDeviceLiveness(ctx, device); err != nil {
+					log.Printf("poll device liveness %s failed: %v", device.ID, err)
+				}
+			}
+		}
+		if result.NextCursor == nil {
+			return nil
+		}
+		pageToken = result.NextCursor
+	}
+}
+
+func (s *Server) pollDeviceLiveness(ctx context.Context, device store.Device) error {
+	if device.OpenZitiIdentityID == "" {
+		return nil
+	}
+	response, err := s.zitiManagementClient.GetIdentityLiveness(ctx, &zitimanagementv1.GetIdentityLivenessRequest{ZitiIdentityId: device.OpenZitiIdentityID})
+	if err != nil {
+		return err
+	}
+	status, err := deviceStatusFromZiti(response.GetEnrollmentState())
+	if err != nil {
+		return err
+	}
+	connectivity := deviceConnectivityFromZiti(response.GetHasEdgeRouterConnection())
+	// An offline device that has not changed has nothing to record; an online
+	// one is written every pass so last_seen_at keeps advancing.
+	if status == device.Status && connectivity == device.Connectivity && connectivity == store.DeviceConnectivityOffline {
+		return nil
+	}
+	now := time.Now().UTC()
+	enrolledAt := device.EnrolledAt
+	if enrolledAt == nil && status == store.DeviceStatusEnrolled {
+		enrolledAt = &now
+	}
+	lastSeenAt := device.LastSeenAt
+	if connectivity == store.DeviceConnectivityOnline {
+		lastSeenAt = &now
+	}
+	if _, err := s.store.UpdateDeviceLiveness(ctx, store.UpdateDeviceLivenessInput{
+		ID:           device.ID,
+		Status:       status,
+		Connectivity: connectivity,
+		EnrolledAt:   enrolledAt,
+		LastSeenAt:   lastSeenAt,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deviceConnectivityFromZiti(hasEdgeRouterConnection bool) store.DeviceConnectivity {
+	if hasEdgeRouterConnection {
+		return store.DeviceConnectivityOnline
+	}
+	return store.DeviceConnectivityOffline
+}
+
+func deviceStatusFromZiti(state zitimanagementv1.IdentityEnrollmentState) (store.DeviceStatus, error) {
+	switch state {
+	case zitimanagementv1.IdentityEnrollmentState_IDENTITY_ENROLLMENT_STATE_PENDING:
+		return store.DeviceStatusPending, nil
+	case zitimanagementv1.IdentityEnrollmentState_IDENTITY_ENROLLMENT_STATE_ENROLLED:
+		return store.DeviceStatusEnrolled, nil
+	default:
+		return "", fmt.Errorf("unknown OpenZiti enrollment state %v", state)
+	}
+}

--- a/internal/server/device_liveness_test.go
+++ b/internal/server/device_liveness_test.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	zitimanagementv1 "github.com/agynio/users/.gen/go/agynio/api/ziti_management/v1"
+	"github.com/agynio/users/internal/store"
+	"github.com/google/uuid"
+)
+
+func TestPollDeviceLivenessRecordsEnrollmentAndConnectivity(t *testing.T) {
+	userID := uuid.New()
+	onlineID := uuid.New()
+	offlineID := uuid.New()
+	fakeStore := newFakeUserStore()
+	fakeStore.users = []store.User{{Meta: store.EntityMeta{ID: userID}}}
+	fakeStore.devices[userID] = []store.Device{
+		storeDevice(onlineID, userID, "laptop", "ziti-online"),
+		storeDevice(offlineID, userID, "phone", "ziti-offline"),
+	}
+	ziti := &fakeZitiManagementClient{
+		livenessByID: map[string]zitimanagementv1.IdentityEnrollmentState{
+			"ziti-online":  zitimanagementv1.IdentityEnrollmentState_IDENTITY_ENROLLMENT_STATE_ENROLLED,
+			"ziti-offline": zitimanagementv1.IdentityEnrollmentState_IDENTITY_ENROLLMENT_STATE_ENROLLED,
+		},
+		onlineByID: map[string]bool{"ziti-online": true},
+	}
+	server := NewWithGroups(fakeStore, &fakeAuthorizationClient{}, &fakeIdentityClient{}, ziti, &fakeGroupsClient{})
+
+	if err := server.PollDeviceLiveness(context.Background()); err != nil {
+		t.Fatalf("PollDeviceLiveness: %v", err)
+	}
+	if len(fakeStore.livenessUpdates) != 2 {
+		t.Fatalf("expected both devices written, got %#v", fakeStore.livenessUpdates)
+	}
+	online := findLivenessUpdate(t, fakeStore, onlineID)
+	if online.Status != store.DeviceStatusEnrolled || online.Connectivity != store.DeviceConnectivityOnline {
+		t.Fatalf("unexpected online update: %#v", online)
+	}
+	if online.EnrolledAt == nil || online.LastSeenAt == nil {
+		t.Fatalf("expected enrolled_at and last_seen_at set: %#v", online)
+	}
+	offline := findLivenessUpdate(t, fakeStore, offlineID)
+	if offline.Connectivity != store.DeviceConnectivityOffline {
+		t.Fatalf("unexpected offline update: %#v", offline)
+	}
+	// Never seen online, so there is no last-seen moment to claim.
+	if offline.LastSeenAt != nil {
+		t.Fatalf("expected no last_seen_at for a device never seen online: %#v", offline)
+	}
+}
+
+// An unchanged offline device is not worth a write; an online one is, so
+// last_seen_at keeps advancing.
+func TestPollDeviceLivenessSkipsUnchangedOfflineDevices(t *testing.T) {
+	userID := uuid.New()
+	deviceID := uuid.New()
+	fakeStore := newFakeUserStore()
+	fakeStore.users = []store.User{{Meta: store.EntityMeta{ID: userID}}}
+	fakeStore.devices[userID] = []store.Device{storeDevice(deviceID, userID, "laptop", "ziti-offline")}
+	ziti := &fakeZitiManagementClient{livenessByID: map[string]zitimanagementv1.IdentityEnrollmentState{
+		"ziti-offline": zitimanagementv1.IdentityEnrollmentState_IDENTITY_ENROLLMENT_STATE_ENROLLED,
+	}}
+	server := NewWithGroups(fakeStore, &fakeAuthorizationClient{}, &fakeIdentityClient{}, ziti, &fakeGroupsClient{})
+
+	if err := server.PollDeviceLiveness(context.Background()); err != nil {
+		t.Fatalf("PollDeviceLiveness: %v", err)
+	}
+	if len(fakeStore.livenessUpdates) != 1 {
+		t.Fatalf("expected the pending -> enrolled transition written, got %#v", fakeStore.livenessUpdates)
+	}
+
+	fakeStore.livenessUpdates = nil
+	if err := server.PollDeviceLiveness(context.Background()); err != nil {
+		t.Fatalf("PollDeviceLiveness: %v", err)
+	}
+	if len(fakeStore.livenessUpdates) != 0 {
+		t.Fatalf("expected no churn once converged, got %#v", fakeStore.livenessUpdates)
+	}
+}
+
+func TestPollDeviceLivenessKeepsGoingWhenOneDeviceFails(t *testing.T) {
+	userID := uuid.New()
+	fakeStore := newFakeUserStore()
+	fakeStore.users = []store.User{{Meta: store.EntityMeta{ID: userID}}}
+	device := storeDevice(uuid.New(), userID, "laptop", "ziti-enrolled")
+	unprovisioned := storeDevice(uuid.New(), userID, "phone", "")
+	fakeStore.devices[userID] = []store.Device{unprovisioned, device}
+	ziti := &fakeZitiManagementClient{livenessByID: map[string]zitimanagementv1.IdentityEnrollmentState{
+		"ziti-enrolled": zitimanagementv1.IdentityEnrollmentState_IDENTITY_ENROLLMENT_STATE_ENROLLED,
+	}}
+	server := NewWithGroups(fakeStore, &fakeAuthorizationClient{}, &fakeIdentityClient{}, ziti, &fakeGroupsClient{})
+
+	if err := server.PollDeviceLiveness(context.Background()); err != nil {
+		t.Fatalf("PollDeviceLiveness: %v", err)
+	}
+	if len(fakeStore.livenessUpdates) != 1 || fakeStore.livenessUpdates[0].ID != device.ID {
+		t.Fatalf("expected the enrolled device still promoted, got %#v", fakeStore.livenessUpdates)
+	}
+}
+
+func findLivenessUpdate(t *testing.T, fakeStore *fakeUserStore, deviceID uuid.UUID) store.UpdateDeviceLivenessInput {
+	t.Helper()
+	for _, update := range fakeStore.livenessUpdates {
+		if update.ID == deviceID {
+			return update
+		}
+	}
+	t.Fatalf("no liveness update for device %s", deviceID)
+	return store.UpdateDeviceLivenessInput{}
+}

--- a/internal/server/group_sync_test.go
+++ b/internal/server/group_sync_test.go
@@ -216,6 +216,7 @@ func storeDevice(id uuid.UUID, userID uuid.UUID, name string, zitiIdentityID str
 		OpenZitiIdentityID: zitiIdentityID,
 		EnrollmentJWT:      &jwt,
 		Status:             store.DeviceStatusPending,
+		Connectivity:       store.DeviceConnectivityOffline,
 		CreatedAt:          time.Unix(1, 0),
 	}
 }
@@ -228,10 +229,11 @@ func mustMarshal(t *testing.T, message proto.Message) []byte {
 }
 
 type fakeUserStore struct {
-	mu           sync.Mutex
-	users        []store.User
-	devices      map[uuid.UUID][]store.Device
-	createDevice store.Device
+	mu              sync.Mutex
+	users           []store.User
+	devices         map[uuid.UUID][]store.Device
+	createDevice    store.Device
+	livenessUpdates []store.UpdateDeviceLivenessInput
 }
 
 func newFakeUserStore() *fakeUserStore {
@@ -371,6 +373,24 @@ func (s *fakeUserStore) DeleteDevice(context.Context, uuid.UUID, uuid.UUID) (sto
 	panic("unexpected DeleteDevice")
 }
 
+func (s *fakeUserStore) UpdateDeviceLiveness(_ context.Context, input store.UpdateDeviceLivenessInput) (store.Device, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.livenessUpdates = append(s.livenessUpdates, input)
+	for identityID, devices := range s.devices {
+		for index, device := range devices {
+			if device.ID == input.ID {
+				s.devices[identityID][index].Status = input.Status
+				s.devices[identityID][index].Connectivity = input.Connectivity
+				s.devices[identityID][index].EnrolledAt = input.EnrolledAt
+				s.devices[identityID][index].LastSeenAt = input.LastSeenAt
+				return s.devices[identityID][index], nil
+			}
+		}
+	}
+	return store.Device{}, fmt.Errorf("device %s not found", input.ID)
+}
+
 type fakeAuthorizationClient struct {
 	authorizationv1.UnimplementedAuthorizationServiceServer
 	mu       sync.Mutex
@@ -474,6 +494,23 @@ type fakeZitiManagementClient struct {
 	createResponse *zitimanagementv1.CreateDeviceIdentityResponse
 	createRequest  *zitimanagementv1.CreateDeviceIdentityRequest
 	patchRequests  []*zitimanagementv1.PatchIdentityRoleAttributesRequest
+	livenessByID   map[string]zitimanagementv1.IdentityEnrollmentState
+	onlineByID     map[string]bool
+	livenessErr    error
+}
+
+func (c *fakeZitiManagementClient) GetIdentityLiveness(_ context.Context, request *zitimanagementv1.GetIdentityLivenessRequest, _ ...grpc.CallOption) (*zitimanagementv1.GetIdentityLivenessResponse, error) {
+	if c.livenessErr != nil {
+		return nil, c.livenessErr
+	}
+	state, ok := c.livenessByID[request.GetZitiIdentityId()]
+	if !ok {
+		state = zitimanagementv1.IdentityEnrollmentState_IDENTITY_ENROLLMENT_STATE_PENDING
+	}
+	return &zitimanagementv1.GetIdentityLivenessResponse{
+		EnrollmentState:         state,
+		HasEdgeRouterConnection: c.onlineByID[request.GetZitiIdentityId()],
+	}, nil
 }
 
 func (c *fakeZitiManagementClient) CreateDeviceIdentity(_ context.Context, request *zitimanagementv1.CreateDeviceIdentityRequest, _ ...grpc.CallOption) (*zitimanagementv1.CreateDeviceIdentityResponse, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,12 +55,14 @@ type userStore interface {
 	CreateDevice(context.Context, store.CreateDeviceInput) (store.Device, error)
 	ListDevices(context.Context, uuid.UUID, int32, *store.PageCursor) (store.DeviceListResult, error)
 	DeleteDevice(context.Context, uuid.UUID, uuid.UUID) (store.Device, error)
+	UpdateDeviceLiveness(context.Context, store.UpdateDeviceLivenessInput) (store.Device, error)
 }
 
 type zitiManagementClient interface {
 	CreateDeviceIdentity(context.Context, *zitimanagementv1.CreateDeviceIdentityRequest, ...grpc.CallOption) (*zitimanagementv1.CreateDeviceIdentityResponse, error)
 	DeleteDeviceIdentity(context.Context, *zitimanagementv1.DeleteDeviceIdentityRequest, ...grpc.CallOption) (*zitimanagementv1.DeleteDeviceIdentityResponse, error)
 	PatchIdentityRoleAttributes(context.Context, *zitimanagementv1.PatchIdentityRoleAttributesRequest, ...grpc.CallOption) (*zitimanagementv1.PatchIdentityRoleAttributesResponse, error)
+	GetIdentityLiveness(context.Context, *zitimanagementv1.GetIdentityLivenessRequest, ...grpc.CallOption) (*zitimanagementv1.GetIdentityLivenessResponse, error)
 }
 
 type groupsClient interface {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,7 +17,7 @@ import (
 const (
 	userColumns     = `identity_id, oidc_subject, name, email, nickname, username, photo_url, created_at, updated_at`
 	apiTokenColumns = `id, identity_id, name, token_hash, token_prefix, expires_at, created_at, last_used_at`
-	deviceColumns   = `id, identity_id, name, openziti_identity_id, enrollment_jwt, status, created_at`
+	deviceColumns   = `id, identity_id, name, openziti_identity_id, enrollment_jwt, status, connectivity, enrolled_at, last_seen_at, created_at`
 )
 
 type EntityMeta struct {
@@ -78,9 +78,14 @@ type APIToken struct {
 
 type DeviceStatus string
 
+type DeviceConnectivity string
+
 const (
 	DeviceStatusPending  DeviceStatus = "pending"
 	DeviceStatusEnrolled DeviceStatus = "enrolled"
+
+	DeviceConnectivityOnline  DeviceConnectivity = "online"
+	DeviceConnectivityOffline DeviceConnectivity = "offline"
 )
 
 type CreateAPITokenInput struct {
@@ -98,7 +103,18 @@ type Device struct {
 	OpenZitiIdentityID string
 	EnrollmentJWT      *string
 	Status             DeviceStatus
+	Connectivity       DeviceConnectivity
+	EnrolledAt         *time.Time
+	LastSeenAt         *time.Time
 	CreatedAt          time.Time
+}
+
+type UpdateDeviceLivenessInput struct {
+	ID           uuid.UUID
+	Status       DeviceStatus
+	Connectivity DeviceConnectivity
+	EnrolledAt   *time.Time
+	LastSeenAt   *time.Time
 }
 
 type CreateDeviceInput struct {
@@ -187,6 +203,9 @@ func scanDevice(row pgx.Row) (Device, error) {
 	var device Device
 	var enrollmentJWT pgtype.Text
 	var status string
+	var connectivity string
+	var enrolledAt pgtype.Timestamptz
+	var lastSeenAt pgtype.Timestamptz
 	if err := row.Scan(
 		&device.ID,
 		&device.IdentityID,
@@ -194,6 +213,9 @@ func scanDevice(row pgx.Row) (Device, error) {
 		&device.OpenZitiIdentityID,
 		&enrollmentJWT,
 		&status,
+		&connectivity,
+		&enrolledAt,
+		&lastSeenAt,
 		&device.CreatedAt,
 	); err != nil {
 		return Device{}, err
@@ -202,12 +224,27 @@ func scanDevice(row pgx.Row) (Device, error) {
 		value := enrollmentJWT.String
 		device.EnrollmentJWT = &value
 	}
+	if enrolledAt.Valid {
+		value := enrolledAt.Time
+		device.EnrolledAt = &value
+	}
+	if lastSeenAt.Valid {
+		value := lastSeenAt.Time
+		device.LastSeenAt = &value
+	}
 	deviceStatus := DeviceStatus(status)
 	switch deviceStatus {
 	case DeviceStatusPending, DeviceStatusEnrolled:
 		device.Status = deviceStatus
 	default:
 		return Device{}, fmt.Errorf("unsupported device status %q", status)
+	}
+	deviceConnectivity := DeviceConnectivity(connectivity)
+	switch deviceConnectivity {
+	case DeviceConnectivityOnline, DeviceConnectivityOffline:
+		device.Connectivity = deviceConnectivity
+	default:
+		return Device{}, fmt.Errorf("unsupported device connectivity %q", connectivity)
 	}
 	return device, nil
 }
@@ -566,6 +603,22 @@ func (s *Store) CreateDevice(ctx context.Context, input CreateDeviceInput) (Devi
 		input.OpenZitiIdentityID,
 		input.EnrollmentJWT,
 		DeviceStatusPending,
+	)
+	device, err := scanDevice(row)
+	if err != nil {
+		return Device{}, err
+	}
+	return device, nil
+}
+
+func (s *Store) UpdateDeviceLiveness(ctx context.Context, input UpdateDeviceLivenessInput) (Device, error) {
+	row := s.pool.QueryRow(ctx,
+		fmt.Sprintf(`UPDATE user_devices SET status = $1, connectivity = $2, enrolled_at = $3, last_seen_at = $4 WHERE id = $5 RETURNING %s`, deviceColumns),
+		input.Status,
+		input.Connectivity,
+		input.EnrolledAt,
+		input.LastSeenAt,
+		input.ID,
 	)
 	device, err := scanDevice(row)
 	if err != nil {

--- a/migrations/0008_device_connectivity.sql
+++ b/migrations/0008_device_connectivity.sql
@@ -1,0 +1,4 @@
+ALTER TABLE user_devices
+    ADD COLUMN connectivity TEXT        NOT NULL DEFAULT 'offline',
+    ADD COLUMN enrolled_at  TIMESTAMPTZ,
+    ADD COLUMN last_seen_at TIMESTAMPTZ;


### PR DESCRIPTION
Devices showed `Pending` in the console forever, however long they had been enrolled and connected.

They were pending by construction: `CreateDevice` hardcodes `pending` on insert, there was no update path, and this service ran no liveness poll at all. `DeviceStatusEnrolled` existed in the store and mapped to the proto, but nothing ever wrote it — dead code.

Adds `PollDeviceLiveness`, mirroring the `PollTunnelLiveness` loop `networks` already runs. Every `DEVICE_LIVENESS_INTERVAL` (default 30s) it calls `GetIdentityLiveness` per device and records enrollment and connectivity as **two axes**, the same shape `TunnelCredential` uses — because "enrolled" and "reachable" are different questions and a single status field cannot answer both.

Write discipline matches tunnels: an unchanged offline device is skipped so the loop stays quiet, an online one is written every pass so `last_seen_at` keeps advancing, and one failing device does not abort the sweep.

Migration `0008` adds `connectivity`, `enrolled_at`, `last_seen_at`. Depends on the `Device` fields added in agynio/api#186 (merged and published).

Verified on the bundle VM: a device went `pending` → `enrolled`/`online` on the first tick with both timestamps set, and stays quiet once converged.

### devspace.yaml

Bundled because it had to be fixed before any of this could be run from sources — it had never worked. Four independent defects, each only visible once the previous was fixed: it patched a deployment named `users-users` (the real one is `users`), its pipeline was named `test:e2e` which current devspace rejects outright, it forwarded host port 50051, and its `buf generate` omitted `--path agynio/api/groups/v1` that CI and the Dockerfile both pass — so the service could never compile in the pod.

Generation is now skipped when `.gen` already matches, because regenerating on every crash-loop restart rate-limited us out of the BSR. The marker keys on the command rather than the module, so the pod must be deleted after an api publish; that caveat is in a comment.